### PR TITLE
Create User: Fix 500 Server Error and 400 Server Error 

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
-
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-DATABASE_URL="mysql://root:diroug@2323@localhost:3306/usersdb"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env*
 
 # vercel
 .vercel

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import prisma from "@/prisma/client";
 
 const createUserSchema = z.object({
-  firstname: z.string().min(1).max(25),
-  lastname: z.string().min(1).max(25),
+  firstName: z.string().min(1).max(25),
+  lastName: z.string().min(1).max(25),
   notes: z.string().min(1),
 });
 
@@ -14,10 +14,10 @@ export async function POST(request: NextRequest) {
   if (!validation.success)
     return NextResponse.json(validation.error.errors, { status: 400 });
 
-  const newUser = await prisma.user.create({
+  const newUser = await prisma.users.create({
     data: {
-      firstname: body.firstname,
-      lastname: body.lastname,
+      firstname: body.firstName,
+      lastname: body.lastName,
       notes: body.notes,
     },
   });

--- a/app/users/new/page.tsx
+++ b/app/users/new/page.tsx
@@ -1,11 +1,16 @@
-"use client";
+'use client';
 import Link from "next/link";
-import SimpleMDE from "react-simplemde-editor";
 import "easymde/dist/easymde.min.css";
 import { useForm, Controller } from "react-hook-form";
 import { Button, TextField } from "@radix-ui/themes";
 import axios from "axios";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
+
+const SimpleMdeEditor = dynamic(
+	() => import("react-simplemde-editor"),
+	{ ssr: false }
+);
 
 const NewUser = () => {
   const router = useRouter();
@@ -17,12 +22,13 @@ const NewUser = () => {
   const {
     register,
     control,
+    reset,
     handleSubmit,
     formState: { errors },
   } = useForm<UserForm>();
   const onSubmit = handleSubmit(async (data) => {
     await axios.post("/api/users", data);
-    router.push("/users/new");
+    reset()
   });
   // firstName and lastName will have correct type
   return (
@@ -45,7 +51,7 @@ const NewUser = () => {
           name="notes"
           control={control}
           render={({ field }) => (
-            <SimpleMDE placeholder="notes..." {...field} />
+            <SimpleMdeEditor placeholder="notes..." {...field} />
           )}
         />
 


### PR DESCRIPTION
## Issue
- Client component causing a server side crash (500 error) due to `react-simplemde-editor` import
- Server returning 400 response due to mismatch in object key spelling 

## Solution
- Used a dynamic import for `react-simplemde-editor` heavily motived by [this](https://github.com/dabit3/next.js-amplify-workshop/issues/21#issuecomment-843188036) issue response on Github 
- Fixed object key spelling in the API Route 

## Additional Info
-Instead of routing the user back to the same page after request completion, I call the `reset` function provided by the `useForm` hook to [reset](https://react-hook-form.com/docs/useform/reset) the form state
- Finally, I added a universal pattern for `.env` in the `.gitignore` to keep env files untracked